### PR TITLE
Add a way to swap between Flutter widgets and the game loop

### DIFF
--- a/lib/game.dart
+++ b/lib/game.dart
@@ -2,45 +2,63 @@ import 'dart:ui';
 import 'dart:typed_data';
 
 abstract class Game {
+  FrameCallback _previousOnBeginFrame;
+  VoidCallback _previousOnDrawFrame;
+  PointerDataPacketCallback _previousOnPointerDataPacket;
+
+  Duration _previous = Duration.ZERO;
 
   void update(double t);
 
   void render(Canvas canvas);
 
   start() {
-    var previous = Duration.ZERO;
+    _previousOnBeginFrame = window.onBeginFrame;
+    _previousOnDrawFrame = window.onDrawFrame;
+    _previousOnPointerDataPacket = window.onPointerDataPacket;
 
-    window.onBeginFrame = (now) {
-      var recorder = new PictureRecorder();
-      var canvas = new Canvas(recorder, new Rect.fromLTWH(
-          0.0, 0.0, window.physicalSize.width, window.physicalSize.height));
-
-      Duration delta = now - previous;
-      if (previous == Duration.ZERO) {
-        delta = Duration.ZERO;
-      }
-      previous = now;
-
-      var t = delta.inMicroseconds / Duration.MICROSECONDS_PER_SECOND;
-
-      update(t);
-      render(canvas);
-
-      var deviceTransform = new Float64List(16)
-        ..[0] = 1.0 // window.devicePixelRatio
-        ..[5] = 1.0 // window.devicePixelRatio
-        ..[10] = 1.0
-        ..[15] = 1.0;
-
-      var builder = new SceneBuilder()
-        ..pushTransform(deviceTransform)
-        ..addPicture(Offset.zero, recorder.endRecording())
-        ..pop();
-
-      window.render(builder.build());
-      window.scheduleFrame();
-    };
+    window.onBeginFrame = _gameLoop;
 
     window.scheduleFrame();
   }
+
+  stop() {
+    window.onBeginFrame = _previousOnBeginFrame;
+    window.onDrawFrame = _previousOnDrawFrame;
+    window.onPointerDataPacket = _previousOnPointerDataPacket;
+  }
+
+  FrameCallback get _gameLoop => (now) {
+    var recorder = new PictureRecorder();
+    var canvas = new Canvas(
+      recorder,
+      new Rect.fromLTWH(0.0, 0.0, window.physicalSize.width, window.physicalSize.height),
+    );
+
+    Duration delta = now - _previous;
+    if (_previous == Duration.ZERO) {
+      delta = Duration.ZERO;
+    }
+    _previous = now;
+
+    var t = delta.inMicroseconds / Duration.MICROSECONDS_PER_SECOND;
+
+    update(t);
+    render(canvas);
+
+    var deviceTransform = new Float64List(16)
+      ..[0] = 1.0 // window.devicePixelRatio
+      ..[5] = 1.0 // window.devicePixelRatio
+      ..[10] = 1.0
+      ..[15] = 1.0;
+
+    var builder = new SceneBuilder()
+      ..pushTransform(deviceTransform)
+      ..addPicture(Offset.zero, recorder.endRecording())
+      ..pop();
+
+    window.render(builder.build());
+    window.scheduleFrame();
+  }
+;
 }

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'dart:async';
-import 'dart:ui';
 
+import 'dart:ui';
 import 'dart:ui' as ui show TextStyle;
 
 class Util {
@@ -26,7 +25,7 @@ class Util {
   }
 
   void enableEvents() {
-    new _CustomBinder();
+    window.onPlatformMessage = BinaryMessages.handlePlatformMessage;
   }
 
   Paragraph text(String text, { double fontSize = 24.0, Color color = Colors.white, fontFamily: 'Arial', double maxWidth = 180.0 }) {
@@ -35,7 +34,4 @@ class Util {
     paragraph.addText(text);
     return paragraph.build()..layout(new ParagraphConstraints(width: maxWidth));
   }
-}
-
-class _CustomBinder extends BindingBase with ServicesBinding {
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flame
 description: A minimalist Flutter game engine
-version: 0.6.1
+version: 0.6.2
 author: Luan Nico <luannico27@gmail.com>
 homepage: https://github.com/luanpotter/flame
 


### PR DESCRIPTION
There's still one issue for this bandaid fix. If you are using touch inputs to invoke `stop()` on the `Game`, then the touch input will be in `state.down` (more than likely), so an assertion exception is thrown (the state never reaches `state.up`).